### PR TITLE
rename internal actions (phase 1)

### DIFF
--- a/predicate/action.yml
+++ b/predicate/action.yml
@@ -1,0 +1,14 @@
+name: 'Build Provenance Predicate'
+description: 'Generate predicate for build provenance attestations'
+author: 'GitHub'
+
+outputs:
+  predicate:
+    description: >
+      The JSON-serialized of the attestation predicate.
+  predicate-type:
+    description: >
+      URI identifying the type of the predicate.
+runs:
+  using: node20
+  main: ../dist/index.js


### PR DESCRIPTION
Preparation for renaming the internal `generate-build-provenance-predicate` to just `predicate`. The fully-qualified reference to the action will be `actions/attest-build-provenance/predicate` so there is plenty of context provided already without duplicate the "build-provenance" part.

The old version will be deleted in a subsequent PR after we've updated the reference in the composite action.

