### PR TITLE
Bump actions/attest to v1.1.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
   steps:
     - uses: actions/attest-build-provenance/predicate@db1dde0f270afe12073070ac7aa802958ae3ec04 # predicate@1.0.0
       id: generate-build-provenance-predicate
-    - uses: actions/attest@495f094150e54d72538674c944ca4daf13e7c67d # v1.0.0
+    - uses: actions/attest@d442d85e120905fa5821e76edb1e07a75b94ee7a # v1.1.0
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Update `actions/attest` to v1.1.0

https://github.com/actions/attest/releases/tag/v1.1.0

Closes #57 