### PR TITLE
bump actions attest from 1.1.2 to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ See [action.yml](action.yml)
 - uses: actions/attest-build-provenance@v1
   with:
     # Path to the artifact serving as the subject of the attestation. Must
-    # specify exactly one of "subject-path" or "subject-digest".
+    # specify exactly one of "subject-path" or "subject-digest". May contain a
+    # glob pattern or list of paths (total subject count cannot exceed 2500).
     subject-path:
 
     # SHA256 digest of the subject for the attestation. Must be in the form
@@ -96,6 +97,15 @@ Attestations are saved in the JSON-serialized [Sigstore bundle][6] format.
 If multiple subjects are being attested at the same time, each attestation will
 be written to the output file on a separate line (using the [JSON Lines][7]
 format).
+
+## Attestation Limits
+
+### Subject Limits
+
+No more than 2500 subjects can be attested at the same time. Subjects will be
+processed in batches 50. After the initial group of 50, each subsequent batch
+will incur an exponentially increasing amount of delay (capped at 1 minute of
+delay per batch) to avoid overwhelming the attestation API.
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,9 @@ branding:
 inputs:
   subject-path:
     description: >
-      Path to the artifact for which provenance will be generated. Must specify
-      exactly one of "subject-path" or "subject-digest".
+      Path to the artifact serving as the subject of the attestation. Must
+      specify exactly one of "subject-path" or "subject-digest". May contain a
+      glob pattern or list of paths (total subject count cannot exceed 2500).
     required: false
   subject-digest:
     description: >
@@ -45,7 +46,7 @@ runs:
   steps:
     - uses: actions/attest-build-provenance/predicate@db1dde0f270afe12073070ac7aa802958ae3ec04 # predicate@1.0.0
       id: generate-build-provenance-predicate
-    - uses: actions/attest@12c083815ed46d5d78222e3824f4a26c42c234d3 # v1.1.2
+    - uses: actions/attest@32795ed9174327efe1734fa6d09c9223658ef225 # v1.2.0
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Bump `actions/attest` from version 1.1.2 to 1.2.0

https://github.com/actions/attest/releases/tag/v1.2.0

Also updates `action.yml` and README to document new subject limits.