### PR TITLE
bump @actions/attest from 1.2.1 to 1.3.0

### DIFF
--- a/__tests__/__snapshots__/main.test.ts.snap
+++ b/__tests__/__snapshots__/main.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`main successfully run main 1`] = `
 {
   "buildDefinition": {
-    "buildType": "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1",
+    "buildType": "https://actions.github.io/buildtypes/workflow/v1",
     "externalParameters": {
       "workflow": {
         "path": ".github/workflows/main.yml",
@@ -16,6 +16,7 @@ exports[`main successfully run main 1`] = `
         "event_name": "push",
         "repository_id": "repo-id",
         "repository_owner_id": "owner-id",
+        "runner_environment": "github-hosted",
       },
     },
     "resolvedDependencies": [
@@ -29,7 +30,7 @@ exports[`main successfully run main 1`] = `
   },
   "runDetails": {
     "builder": {
-      "id": "https://github.com/actions/runner/github-hosted",
+      "id": "https://github.com/owner/shared/.github/workflows/build.yml@main",
     },
     "metadata": {
       "invocationId": "https://github.com/owner/repo/actions/runs/run-id/attempts/run-attempt",

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -25,6 +25,7 @@ describe('main', () => {
     ref: 'refs/heads/main',
     sha: 'babca52ab0c93ae16539e5923cb0d7403b9a093b',
     workflow_ref: 'owner/repo/.github/workflows/main.yml@main',
+    job_workflow_ref: 'owner/shared/.github/workflows/build.yml@main',
     event_name: 'push',
     repository_id: 'repo-id',
     repository_owner_id: 'owner-id',

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -2847,6 +2847,25 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 
+proc-log
+ISC
+The ISC License
+
+Copyright (c) GitHub, Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
 promise-retry
 MIT
 Copyright (c) 2014 IndigoUnited

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "actions/attest-build-provenance",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest-build-provenance",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/attest": "^1.2.1",
+        "@actions/attest": "^1.3.0",
         "@actions/core": "^1.10.1"
       },
       "devDependencies": {
@@ -45,16 +45,16 @@
       }
     },
     "node_modules/@actions/attest": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.2.1.tgz",
-      "integrity": "sha512-ZLfmO6o2x3UL2BG++oIHMPx5kApWr8Uy1cgiiafXpHgamsqFUPjUtcp0/gpOaXkxUZftdVno7NwBTisw8qr9UA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.3.0.tgz",
+      "integrity": "sha512-Xmv+HIefU8PMx3q+BwGmL28MLyQ2FF05ROZjH+iuoQ9q43qzmbJmmzou3NBOSspUa1N2nVtirPq7jPj9g8AMEg==",
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",
         "@actions/http-client": "^2.2.1",
         "@octokit/plugin-retry": "^6.0.1",
-        "@sigstore/bundle": "^2.3.0",
-        "@sigstore/sign": "^2.3.0",
+        "@sigstore/bundle": "^2.3.2",
+        "@sigstore/sign": "^2.3.2",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.1.0"
       }
@@ -1338,17 +1338,17 @@
       }
     },
     "node_modules/@npmcli/agent/node_modules/lru-cache": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.1.tgz",
-      "integrity": "sha512-tS24spDe/zXhWbNPErCHs/AGOzbKGHT+ybSBqmdLm8WZ1xXLWvH8Qn71QPAlqVhd0qUTWjy+Kl9JmISgDdEjsA==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
       "engines": {
         "node": "14 || >=16.14"
       }
     },
     "node_modules/@npmcli/fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
-      "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+      "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -1500,11 +1500,11 @@
       }
     },
     "node_modules/@sigstore/bundle": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.1.tgz",
-      "integrity": "sha512-eqV17lO3EIFqCWK3969Rz+J8MYrRZKw9IBHpSo6DEcEX2c+uzDFOgHE9f2MnyDpfs48LFO4hXmk9KhQ74JzU1g==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.2.tgz",
+      "integrity": "sha512-wueKWDk70QixNLB363yHc2D2ItTgYiMTdPwK8D9dKQMR3ZQ0c35IxP5xnwQ8cNLoCgCRcHf14kE+CLIvNX1zmA==",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.3.1"
+        "@sigstore/protobuf-specs": "^0.3.2"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -1519,22 +1519,24 @@
       }
     },
     "node_modules/@sigstore/protobuf-specs": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.1.tgz",
-      "integrity": "sha512-aIL8Z9NsMr3C64jyQzE0XlkEyBLpgEJJFDHLVVStkFV5Q3Il/r/YtY6NJWKQ4cy4AE7spP1IX5Jq7VCAxHHMfQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.2.tgz",
+      "integrity": "sha512-c6B0ehIWxMI8wiS/bj6rHMPqeFvngFV7cDU/MY+B16P9Z3Mp9k8L93eYZ7BYzSickzuqAQqAq0V956b3Ju6mLw==",
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/@sigstore/sign": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.0.tgz",
-      "integrity": "sha512-tsAyV6FC3R3pHmKS880IXcDJuiFJiKITO1jxR1qbplcsBkZLBmjrEw5GbC7ikD6f5RU1hr7WnmxB/2kKc1qUWQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.2.tgz",
+      "integrity": "sha512-5Vz5dPVuunIIvC5vBb0APwo7qKA4G9yM48kPWJT+OEERs40md5GoUR1yedwpekWZ4m0Hhw44m6zU+ObsON+iDA==",
       "dependencies": {
-        "@sigstore/bundle": "^2.3.0",
+        "@sigstore/bundle": "^2.3.2",
         "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.3.1",
-        "make-fetch-happen": "^13.0.0"
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "make-fetch-happen": "^13.0.1",
+        "proc-log": "^4.2.0",
+        "promise-retry": "^2.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -2520,9 +2522,9 @@
       "license": "MIT"
     },
     "node_modules/cacache": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.2.tgz",
-      "integrity": "sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.3.tgz",
+      "integrity": "sha512-qXCd4rh6I07cnDqh8V48/94Tc/WSfj+o3Gn6NZ0aZovS255bUx8O13uKxRFd2eWG0xgsco7+YItQNPaa5E85hg==",
       "dependencies": {
         "@npmcli/fs": "^3.1.0",
         "fs-minipass": "^3.0.0",
@@ -2550,30 +2552,30 @@
       }
     },
     "node_modules/cacache/node_modules/glob": {
-      "version": "10.3.12",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.12.tgz",
-      "integrity": "sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.6",
-        "minimatch": "^9.0.1",
-        "minipass": "^7.0.4",
-        "path-scurry": "^1.10.2"
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/cacache/node_modules/lru-cache": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.1.tgz",
-      "integrity": "sha512-tS24spDe/zXhWbNPErCHs/AGOzbKGHT+ybSBqmdLm8WZ1xXLWvH8Qn71QPAlqVhd0qUTWjy+Kl9JmISgDdEjsA==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -4846,8 +4848,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.3.6",
-      "license": "BlueOak-1.0.0",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -5873,9 +5876,9 @@
       "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.0.tgz",
-      "integrity": "sha512-7ThobcL8brtGo9CavByQrQi+23aIfgYU++wg4B87AIS8Rb2ZBt/MEaDqzA00Xwv/jUjAjYkLHjVolYuTLKda2A==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+      "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
       "dependencies": {
         "@npmcli/agent": "^2.0.0",
         "cacache": "^18.0.0",
@@ -5886,6 +5889,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^0.6.3",
+        "proc-log": "^4.2.0",
         "promise-retry": "^2.0.1",
         "ssri": "^10.0.0"
       },
@@ -5988,24 +5992,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/markdownlint-cli/node_modules/jackspeak": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
-      "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
-      "dev": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/markdownlint-cli/node_modules/minimatch": {
@@ -6113,9 +6099,9 @@
       }
     },
     "node_modules/minipass-fetch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.4.tgz",
-      "integrity": "sha512-jHAqnA728uUpIaFm7NWsCnqKT6UqZz7GcI/bDpPATuwYyKwJwW0remxSCxUlKiEty+eopHGa3oc8WxgQ1FFJqg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
+      "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
@@ -6889,6 +6875,14 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -7401,9 +7395,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.5.tgz",
-      "integrity": "sha512-bSf16tAFkGeRlUNDjXu8FzaMQt6g2HZJrun7mtMbIPOddxt3GLMSz5VWUWcqTJUPfLEaDIepGxv+bYQW49596A==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
+      "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
       "dependencies": {
         "minipass": "^7.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest-build-provenance",
   "description": "Generate signed build provenance attestations",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest-build-provenance",
@@ -70,7 +70,7 @@
     ]
   },
   "dependencies": {
-    "@actions/attest": "^1.2.1",
+    "@actions/attest": "^1.3.0",
     "@actions/core": "^1.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Update `@actions/attest` to v1.3.0. 

Includes generation of new GHA provenance predicates with build type:

```
https://actions.github.io/buildtypes/workflow/v1
```