### PR TITLE
Bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ attest:
    ```
 
    The `id-token` permission gives the action the ability to mint the OIDC token
-   permission is necessary to persist the attestation. The `attestations`
+   necessary to request a Sigstore signing certificate. The `attestations`
    permission is necessary to persist the attestation.
 
 1. Add the following to your workflow after your artifact has been built:

--- a/action.yml
+++ b/action.yml
@@ -44,9 +44,9 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/attest-build-provenance/predicate@db1dde0f270afe12073070ac7aa802958ae3ec04 # predicate@1.0.0
+    - uses: actions/attest-build-provenance/predicate@46e4ff8b824dc6ae13c8f92c8ba69907e2d39b4e # predicate@1.1.0
       id: generate-build-provenance-predicate
-    - uses: actions/attest@32795ed9174327efe1734fa6d09c9223658ef225 # v1.2.0
+    - uses: actions/attest@b24527d9cbfd6c27196c10f8dccbacaa2a1c53f2 # v1.3.0
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Bumps the following dependencies:
* `actions/attest-build-provenance/predicate` from 1.0.0 to [1.1.0](https://github.com/actions/attest-build-provenance/releases/tag/predicate%401.1.0)
  * Switch to new GH provenance build type
* `actions/attest` from 1.2.0 to [1.3.0](https://github.com/actions/attest/releases/tag/v1.3.0)
  * Dynamic construction of GitHub API URLs based on GITHUB_SERVER_URL
  * Improved handling of Rekor 409 responses
  * Bugfix - detection of registries with support for the OCI referrers API

Also includes small README fix