### PR TITLE
add multi-subject examples to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ jobs:
           subject-path: '${{ github.workspace }}/my-app'
 ```
 
-### Identify Subjects by Wildcard
+### Identify Multiple Subjects
 
 If you are generating multiple artifacts, you can generate a provenance
 attestation for each by using a wildcard in the `subject-path` input.
@@ -152,6 +152,23 @@ attestation for each by using a wildcard in the `subject-path` input.
 
 For supported wildcards along with behavior and documentation, see
 [@actions/glob][8] which is used internally to search for files.
+
+Alternatively, you can explicitly list multiple subjects with either a comma or
+newline delimited list:
+
+```yaml
+- uses: actions/attest-build-provenance@v1
+  with:
+    subject-path: 'dist/foo, dist/bar'
+```
+
+```yaml
+- uses: actions/attest-build-provenance@v1
+  with:
+    subject-path: |
+      dist/foo
+      dist/bar
+```
 
 ### Container Image
 


### PR DESCRIPTION
Update README with examples of using comma/newline delimited lists to identify multiple attestation subjects.

closes #78 