### PR TITLE
bump actions/attest from 1.3.1 to 1.3.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
   steps:
     - uses: actions/attest-build-provenance/predicate@46e4ff8b824dc6ae13c8f92c8ba69907e2d39b4e # predicate@1.1.0
       id: generate-build-provenance-predicate
-    - uses: actions/attest@0fdba851bc306a96f085a0acd31cf892a7e14f2d # v1.3.1
+    - uses: actions/attest@8afbcf6e5e31a04f9ef7ca7ee40a0d91e263da5a # v1.3.2
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Bump the `actions/attest` action from version `1.3.1` to `1.3.2`.

https://github.com/actions/attest/releases/tag/v1.3.2

Includes the increased timeout value for OCI operations.

Fixes https://github.com/actions/attest/issues/91