### PR TITLE
disable typescript-standard super linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -46,4 +46,5 @@ jobs:
           TYPESCRIPT_DEFAULT_STYLE: prettier
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JAVASCRIPT_STANDARD: false
+          VALIDATE_TYPESCRIPT_STANDARD: false
           VALIDATE_JSCPD: false


### PR DESCRIPTION
Disabling the some of the linter checks in the super-linter workflow that are raising errors after the most recent upgrade.

<img width="740" alt="image" src="https://github.com/user-attachments/assets/0637af66-e189-4bc4-9522-4a86b73bb01a">

Instead of running both TYPESCRIPT_PRETTIER and TYPESCRIPT_STANDARD, we'll disable the TYPESCRIPT_STANDARD linter.

More info [here](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md#javascript_default_style-and-typescript_default_style)
