### PR TITLE
dynamic construction of oidc issuer

### DIFF
--- a/__tests__/__snapshots__/main.test.ts.snap
+++ b/__tests__/__snapshots__/main.test.ts.snap
@@ -1,6 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`main successfully run main 1`] = `
+exports[`main when a non-default OIDC issuer is used successfully run main 1`] = `
+{
+  "buildDefinition": {
+    "buildType": "https://actions.github.io/buildtypes/workflow/v1",
+    "externalParameters": {
+      "workflow": {
+        "path": ".github/workflows/main.yml",
+        "ref": "main",
+        "repository": "https://example-01.ghe.com/owner/repo",
+      },
+    },
+    "internalParameters": {
+      "github": {
+        "event_name": "push",
+        "repository_id": "repo-id",
+        "repository_owner_id": "owner-id",
+        "runner_environment": "github-hosted",
+      },
+    },
+    "resolvedDependencies": [
+      {
+        "digest": {
+          "gitCommit": "babca52ab0c93ae16539e5923cb0d7403b9a093b",
+        },
+        "uri": "git+https://example-01.ghe.com/owner/repo@refs/heads/main",
+      },
+    ],
+  },
+  "runDetails": {
+    "builder": {
+      "id": "https://example-01.ghe.com/owner/shared/.github/workflows/build.yml@main",
+    },
+    "metadata": {
+      "invocationId": "https://example-01.ghe.com/owner/repo/actions/runs/run-id/attempts/run-attempt",
+    },
+  },
+}
+`;
+
+exports[`main when the default OIDC issuer is used successfully run main 1`] = `
 {
   "buildDefinition": {
     "buildType": "https://actions.github.io/buildtypes/workflow/v1",

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -13,61 +13,13 @@ setFailedMock.mockImplementation(() => {})
 describe('main', () => {
   let outputs = {} as Record<string, string>
   const originalEnv = process.env
-  const issuer = 'https://token.actions.githubusercontent.com'
-  const audience = 'nobody'
-  const jwksPath = '/.well-known/jwks.json'
-  const tokenPath = '/token'
 
-  const claims = {
-    iss: issuer,
-    aud: 'nobody',
-    repository: 'owner/repo',
-    ref: 'refs/heads/main',
-    sha: 'babca52ab0c93ae16539e5923cb0d7403b9a093b',
-    workflow_ref: 'owner/repo/.github/workflows/main.yml@main',
-    job_workflow_ref: 'owner/shared/.github/workflows/build.yml@main',
-    event_name: 'push',
-    repository_id: 'repo-id',
-    repository_owner_id: 'owner-id',
-    run_id: 'run-id',
-    run_attempt: 'run-attempt',
-    runner_environment: 'github-hosted'
-  }
-
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.resetAllMocks()
 
     setOutputMock.mockImplementation((key, value) => {
       outputs[key] = value
     })
-
-    process.env = {
-      ...originalEnv,
-      ACTIONS_ID_TOKEN_REQUEST_URL: `${issuer}${tokenPath}?`,
-      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'token',
-      GITHUB_SERVER_URL: 'https://github.com',
-      GITHUB_REPOSITORY: claims.repository
-    }
-
-    // Generate JWT signing key
-    const key = await jose.generateKeyPair('PS256')
-
-    // Create JWK, JWKS, and JWT
-    const kid = '12345'
-    const jwk = await jose.exportJWK(key.publicKey)
-    const jwks = { keys: [{ ...jwk, kid }] }
-    const jwt = await new jose.SignJWT(claims)
-      .setProtectedHeader({ alg: 'PS256', kid })
-      .sign(key.privateKey)
-
-    // Mock OpenID configuration and JWKS endpoints
-    nock(issuer)
-      .get('/.well-known/openid-configuration')
-      .reply(200, { jwks_uri: `${issuer}${jwksPath}` })
-    nock(issuer).get(jwksPath).reply(200, jwks)
-
-    // Mock OIDC token endpoint for populating the provenance
-    nock(issuer).get(tokenPath).query({ audience }).reply(200, { value: jwt })
   })
 
   afterEach(() => {
@@ -75,14 +27,131 @@ describe('main', () => {
     process.env = originalEnv
   })
 
-  it('successfully run main', async () => {
-    // Run the main function
-    await main.run()
+  describe('when the default OIDC issuer is used', () => {
+    const issuer = 'https://token.actions.githubusercontent.com'
+    const audience = 'nobody'
+    const jwksPath = '/.well-known/jwks.json'
+    const tokenPath = '/token'
 
-    // Verify that outputs were set correctly
-    expect(setOutputMock).toHaveBeenCalledTimes(2)
+    const claims = {
+      iss: issuer,
+      aud: 'nobody',
+      repository: 'owner/repo',
+      ref: 'refs/heads/main',
+      sha: 'babca52ab0c93ae16539e5923cb0d7403b9a093b',
+      workflow_ref: 'owner/repo/.github/workflows/main.yml@main',
+      job_workflow_ref: 'owner/shared/.github/workflows/build.yml@main',
+      event_name: 'push',
+      repository_id: 'repo-id',
+      repository_owner_id: 'owner-id',
+      run_id: 'run-id',
+      run_attempt: 'run-attempt',
+      runner_environment: 'github-hosted'
+    }
 
-    expect(outputs['predicate']).toMatchSnapshot()
-    expect(outputs['predicate-type']).toBe('https://slsa.dev/provenance/v1')
+    beforeEach(async () => {
+      process.env = {
+        ...originalEnv,
+        ACTIONS_ID_TOKEN_REQUEST_URL: `${issuer}${tokenPath}?`,
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'token',
+        GITHUB_SERVER_URL: 'https://github.com',
+        GITHUB_REPOSITORY: claims.repository
+      }
+
+      // Generate JWT signing key
+      const key = await jose.generateKeyPair('PS256')
+
+      // Create JWK, JWKS, and JWT
+      const kid = '12345'
+      const jwk = await jose.exportJWK(key.publicKey)
+      const jwks = { keys: [{ ...jwk, kid }] }
+      const jwt = await new jose.SignJWT(claims)
+        .setProtectedHeader({ alg: 'PS256', kid })
+        .sign(key.privateKey)
+
+      // Mock OpenID configuration and JWKS endpoints
+      nock(issuer)
+        .get('/.well-known/openid-configuration')
+        .reply(200, { jwks_uri: `${issuer}${jwksPath}` })
+      nock(issuer).get(jwksPath).reply(200, jwks)
+
+      // Mock OIDC token endpoint for populating the provenance
+      nock(issuer).get(tokenPath).query({ audience }).reply(200, { value: jwt })
+    })
+
+    it('successfully run main', async () => {
+      // Run the main function
+      await main.run()
+
+      // Verify that outputs were set correctly
+      expect(setOutputMock).toHaveBeenCalledTimes(2)
+
+      expect(outputs['predicate']).toMatchSnapshot()
+      expect(outputs['predicate-type']).toBe('https://slsa.dev/provenance/v1')
+    })
+  })
+
+  describe('when a non-default OIDC issuer is used', () => {
+    const issuer = 'https://token.actions.example-01.ghe.com'
+    const audience = 'nobody'
+    const jwksPath = '/.well-known/jwks.json'
+    const tokenPath = '/token'
+
+    const claims = {
+      iss: issuer,
+      aud: 'nobody',
+      repository: 'owner/repo',
+      ref: 'refs/heads/main',
+      sha: 'babca52ab0c93ae16539e5923cb0d7403b9a093b',
+      workflow_ref: 'owner/repo/.github/workflows/main.yml@main',
+      job_workflow_ref: 'owner/shared/.github/workflows/build.yml@main',
+      event_name: 'push',
+      repository_id: 'repo-id',
+      repository_owner_id: 'owner-id',
+      run_id: 'run-id',
+      run_attempt: 'run-attempt',
+      runner_environment: 'github-hosted'
+    }
+
+    beforeEach(async () => {
+      process.env = {
+        ...originalEnv,
+        ACTIONS_ID_TOKEN_REQUEST_URL: `${issuer}${tokenPath}?`,
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'token',
+        GITHUB_SERVER_URL: 'https://example-01.ghe.com',
+        GITHUB_REPOSITORY: claims.repository
+      }
+
+      // Generate JWT signing key
+      const key = await jose.generateKeyPair('PS256')
+
+      // Create JWK, JWKS, and JWT
+      const kid = '12345'
+      const jwk = await jose.exportJWK(key.publicKey)
+      const jwks = { keys: [{ ...jwk, kid }] }
+      const jwt = await new jose.SignJWT(claims)
+        .setProtectedHeader({ alg: 'PS256', kid })
+        .sign(key.privateKey)
+
+      // Mock OpenID configuration and JWKS endpoints
+      nock(issuer)
+        .get('/.well-known/openid-configuration')
+        .reply(200, { jwks_uri: `${issuer}${jwksPath}` })
+      nock(issuer).get(jwksPath).reply(200, jwks)
+
+      // Mock OIDC token endpoint for populating the provenance
+      nock(issuer).get(tokenPath).query({ audience }).reply(200, { value: jwt })
+    })
+
+    it('successfully run main', async () => {
+      // Run the main function
+      await main.run()
+
+      // Verify that outputs were set correctly
+      expect(setOutputMock).toHaveBeenCalledTimes(2)
+
+      expect(outputs['predicate']).toMatchSnapshot()
+      expect(outputs['predicate-type']).toBe('https://slsa.dev/provenance/v1')
+    })
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actions/attest-build-provenance",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest-build-provenance",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@actions/attest": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest-build-provenance",
   "description": "Generate signed build provenance attestations",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest-build-provenance",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,21 @@
 import { buildSLSAProvenancePredicate } from '@actions/attest'
 import * as core from '@actions/core'
 
+const VALID_SERVER_URLS = [
+  'https://github.com',
+  new RegExp('^https://[a-z0-9-]+\\.ghe\\.com$')
+] as const
+
 /**
  * The main function for the action.
  * @returns {Promise<void>} Resolves when the action is complete.
  */
 export async function run(): Promise<void> {
   try {
+    const issuer = getIssuer()
+
     // Calculate subject from inputs and generate provenance
-    const predicate = await buildSLSAProvenancePredicate()
+    const predicate = await buildSLSAProvenancePredicate(issuer)
 
     core.setOutput('predicate', predicate.params)
     core.setOutput('predicate-type', predicate.type)
@@ -17,4 +24,22 @@ export async function run(): Promise<void> {
     // Fail the workflow run if an error occurs
     core.setFailed(error.message)
   }
+}
+
+// Derive the current OIDC issuer based on the server URL
+function getIssuer(): string {
+  const serverURL = process.env.GITHUB_SERVER_URL || 'https://github.com'
+
+  // Ensure the server URL is a valid GitHub server URL
+  if (!VALID_SERVER_URLS.some(valid_url => serverURL.match(valid_url))) {
+    throw new Error(`Invalid server URL: ${serverURL}`)
+  }
+
+  let host = new URL(serverURL).hostname
+
+  if (host === 'github.com') {
+    host = 'githubusercontent.com'
+  }
+
+  return `https://token.actions.${host}`
 }


### PR DESCRIPTION
Dynamically constructs the URL for the OIDC issuer passed to the `buildSLSAProvenancePredicate` function. Allows the correct issuer to be determined from the value of the`GITHUB_SERVER_URL` environment variable.