### PR TITLE
bump @actions/attest from 1.4.1 to 1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "actions/attest-build-provenance",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest-build-provenance",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
-        "@actions/attest": "^1.4.1",
+        "@actions/attest": "^1.4.2",
         "@actions/core": "^1.10.1"
       },
       "devDependencies": {
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@actions/attest": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.4.1.tgz",
-      "integrity": "sha512-IEwE9SxHUGZUogp7s9nb8KCcj+83VQ62TR7r6J/HUh94KN+nU+V9AvqnEg1sGCKmFo9BUVX8lV7D+M2tdfVxaw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.4.2.tgz",
+      "integrity": "sha512-VCE5xFPexHc/iBD77b5Rip1ClYFF5j6vE7HxNxFga4OUnRwM6gXdObcz4cDRJsyp6ud4BgEqFUJYNinMnpPYMQ==",
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest-build-provenance",
   "description": "Generate signed build provenance attestations",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest-build-provenance",
@@ -70,7 +70,7 @@
     ]
   },
   "dependencies": {
-    "@actions/attest": "^1.4.1",
+    "@actions/attest": "^1.4.2",
     "@actions/core": "^1.10.1"
   },
   "devDependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,21 +1,14 @@
 import { buildSLSAProvenancePredicate } from '@actions/attest'
 import * as core from '@actions/core'
 
-const VALID_SERVER_URLS = [
-  'https://github.com',
-  new RegExp('^https://[a-z0-9-]+\\.ghe\\.com$')
-] as const
-
 /**
  * The main function for the action.
  * @returns {Promise<void>} Resolves when the action is complete.
  */
 export async function run(): Promise<void> {
   try {
-    const issuer = getIssuer()
-
     // Calculate subject from inputs and generate provenance
-    const predicate = await buildSLSAProvenancePredicate(issuer)
+    const predicate = await buildSLSAProvenancePredicate()
 
     core.setOutput('predicate', predicate.params)
     core.setOutput('predicate-type', predicate.type)
@@ -24,22 +17,4 @@ export async function run(): Promise<void> {
     // Fail the workflow run if an error occurs
     core.setFailed(error.message)
   }
-}
-
-// Derive the current OIDC issuer based on the server URL
-function getIssuer(): string {
-  const serverURL = process.env.GITHUB_SERVER_URL || 'https://github.com'
-
-  // Ensure the server URL is a valid GitHub server URL
-  if (!VALID_SERVER_URLS.some(valid_url => serverURL.match(valid_url))) {
-    throw new Error(`Invalid server URL: ${serverURL}`)
-  }
-
-  let host = new URL(serverURL).hostname
-
-  if (host === 'github.com') {
-    host = 'githubusercontent.com'
-  }
-
-  return `https://token.actions.${host}`
 }


### PR DESCRIPTION
Updates the `@actions/attest` library from version 1.4.1 to 1.4.2 (see https://github.com/actions/toolkit/pull/1823). Includes the fix for #222.

