### PR TITLE
bump predicate from 1.1.3 to 1.1.4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/attest-build-provenance/predicate@f1185f1959cdaeda41a7f5a7b43cbe6b58a7a793 # predicate@1.1.3
+    - uses: actions/attest-build-provenance/predicate@36fa7d009e22618ca7cd599486979b8150596c74 # predicate@1.1.4
       id: generate-build-provenance-predicate
     - uses: actions/attest@67422f5511b7ff725f4dbd6fb9bd2cd925c65a8d # v1.4.1
       id: attest


### PR DESCRIPTION
Bump `actions/attest-build-provenance/predicate` from 1.1.3 to 1.1.4

Includes `@actions/attest` 1.5.0 (see #309)