### PR TITLE
Bump actions/attest from 2.0.0 to 2.0.1

### DIFF
--- a/.github/workflows/prober.yml
+++ b/.github/workflows/prober.yml
@@ -29,7 +29,7 @@ jobs:
           date > artifact
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         env:
           INPUT_PRIVATE-SIGNING: ${{ inputs.sigstore == 'github' && 'true' || 'false' }}
         with:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ attest:
 1. Add the following to your workflow after your artifact has been built:
 
    ```yaml
-   - uses: actions/attest-build-provenance@v1
+   - uses: actions/attest-build-provenance@v2
      with:
        subject-path: '<PATH TO ARTIFACT>'
    ```
@@ -58,7 +58,7 @@ attest:
 See [action.yml](action.yml)
 
 ```yaml
-- uses: actions/attest-build-provenance@v1
+- uses: actions/attest-build-provenance@v2
   with:
     # Path to the artifact serving as the subject of the attestation. Must
     # specify exactly one of "subject-path" or "subject-digest". May contain a
@@ -126,6 +126,7 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -137,7 +138,7 @@ jobs:
       - name: Build artifact
         run: make my-app
       - name: Attest
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         with:
           subject-path: '${{ github.workspace }}/my-app'
 ```
@@ -148,7 +149,7 @@ If you are generating multiple artifacts, you can attest all of them at the same
 time by using a wildcard in the `subject-path` input.
 
 ```yaml
-- uses: actions/attest-build-provenance@v1
+- uses: actions/attest-build-provenance@v2
   with:
     subject-path: 'dist/**/my-bin-*'
 ```
@@ -160,13 +161,13 @@ Alternatively, you can explicitly list multiple subjects with either a comma or
 newline delimited list:
 
 ```yaml
-- uses: actions/attest-build-provenance@v1
+- uses: actions/attest-build-provenance@v2
   with:
     subject-path: 'dist/foo, dist/bar'
 ```
 
 ```yaml
-- uses: actions/attest-build-provenance@v1
+- uses: actions/attest-build-provenance@v2
   with:
     subject-path: |
       dist/foo
@@ -226,7 +227,7 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
       - name: Attest
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         id: attest
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
   steps:
     - uses: actions/attest-build-provenance/predicate@36fa7d009e22618ca7cd599486979b8150596c74 # predicate@1.1.4
       id: generate-build-provenance-predicate
-    - uses: actions/attest@v2.0.0
+    - uses: actions/attest@v2.0.1
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Bump `actions/attest` from 2.0.0 to 2.0.1. Includes the bug fix to deduplicate subjects before adding them to the in-toto statement.