### PR TITLE
Bump actions/attest from 2.2.0 to 2.2.1

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Lint Codebase
         id: super-linter
-        uses: super-linter/super-linter/slim@v7
+        uses: super-linter/super-linter/slim@v7.2.1
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: dist/**/*

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
   steps:
     - uses: actions/attest-build-provenance/predicate@36fa7d009e22618ca7cd599486979b8150596c74 # predicate@1.1.4
       id: generate-build-provenance-predicate
-    - uses: actions/attest@v2.2.0
+    - uses: actions/attest@v2.2.1
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Updates the reference to the `actions/attest` action from v2.2.0 to v2.2.1.

* https://github.com/actions/attest/releases/tag/v2.2.1

This includes the update of the `@actions/attest` package from v1.5.0 to v.1.6.0 with the following change:

* https://github.com/actions/toolkit/pull/1969