### PR TITLE
bump @actions/attest from 1.5.0 to 1.6.0

### DIFF
--- a/__tests__/__snapshots__/main.test.ts.snap
+++ b/__tests__/__snapshots__/main.test.ts.snap
@@ -7,7 +7,7 @@ exports[`main when a non-default OIDC issuer is used successfully run main 1`] =
     "externalParameters": {
       "workflow": {
         "path": ".github/workflows/main.yml",
-        "ref": "main",
+        "ref": "refs/heads/main",
         "repository": "https://example-01.ghe.com/owner/repo",
       },
     },
@@ -46,7 +46,7 @@ exports[`main when the default OIDC issuer is used successfully run main 1`] = `
     "externalParameters": {
       "workflow": {
         "path": ".github/workflows/main.yml",
-        "ref": "main",
+        "ref": "refs/heads/main",
         "repository": "https://github.com/owner/repo",
       },
     },

--- a/dist/index.js
+++ b/dist/index.js
@@ -377,11 +377,9 @@ const buildSLSAProvenancePredicate = (issuer) => __awaiter(void 0, void 0, void 
     // Split just the path and ref from the workflow string.
     // owner/repo/.github/workflows/main.yml@main =>
     //   .github/workflows/main.yml, main
-    const [workflowPath, ...workflowRefChunks] = claims.workflow_ref
+    const [workflowPath] = claims.workflow_ref
         .replace(`${claims.repository}/`, '')
         .split('@');
-    // Handle case where tag contains `@` (e.g: when using changesets in a monorepo context),
-    const workflowRef = workflowRefChunks.join('@');
     return {
         type: SLSA_PREDICATE_V1_TYPE,
         params: {
@@ -389,7 +387,7 @@ const buildSLSAProvenancePredicate = (issuer) => __awaiter(void 0, void 0, void 
                 buildType: GITHUB_BUILD_TYPE,
                 externalParameters: {
                     workflow: {
-                        ref: workflowRef,
+                        ref: claims.ref,
                         repository: `${serverURL}/${claims.repository}`,
                         path: workflowPath
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "actions/attest-build-provenance",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest-build-provenance",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
-        "@actions/attest": "^1.5.0",
+        "@actions/attest": "^1.6.0",
         "@actions/core": "^1.11.1"
       },
       "devDependencies": {
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@actions/attest": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.5.0.tgz",
-      "integrity": "sha512-KIalYPhJu0/6LOhT+Bhw0GncresPCiY1onLq8n0whjoJX0/M7UQmgXkn1ioQnNrkzEhcs6wVKwylusbMwTOX0g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.6.0.tgz",
+      "integrity": "sha512-D+VcLqUImA7Gr5qPQrRGvNUJKzP67IHV3/ofF5QBpLqe3Vih3hb74k9ZtjHXamiZNVZi2Wkphj8yTi4/xiWkwQ==",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest-build-provenance",
   "description": "Generate signed build provenance attestations",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest-build-provenance",
@@ -70,7 +70,7 @@
     ]
   },
   "dependencies": {
-    "@actions/attest": "^1.5.0",
+    "@actions/attest": "^1.6.0",
     "@actions/core": "^1.11.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Update the `@actions/attest` package from 1.5.0 to 1.6.0. Includes the following:

* https://github.com/actions/toolkit/pull/1969