### PR TITLE
bump predicate from 1.1.4 to 1.1.5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/attest-build-provenance/predicate@36fa7d009e22618ca7cd599486979b8150596c74 # predicate@1.1.4
+    - uses: actions/attest-build-provenance/predicate@1176ef556905f349f669722abf30bce1a6e16e01 # predicate@1.1.5
       id: generate-build-provenance-predicate
     - uses: actions/attest@v2.2.1
       id: attest


### PR DESCRIPTION
Bump `actions/attest-build-provenance/predicate` from 1.1.4 to 1.1.5

Includes `@actions/attest` 1.6.0 (see #484)