### PR TITLE
chore: reference actions/attest by hash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
   steps:
     - uses: actions/attest-build-provenance/predicate@1176ef556905f349f669722abf30bce1a6e16e01 # predicate@1.1.5
       id: generate-build-provenance-predicate
-    - uses: actions/attest@v2.2.1
+    - uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Fixes regression introduced since https://github.com/actions/attest-build-provenance/pull/321

See https://github.com/jquery/jquery/issues/5266 for rationale (cc @gabibguti)