### PR TITLE
docs: bump docker/build-push-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
         id: push
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

The latest [docker/build-push-action release](https://github.com/docker/build-push-action/releases) is v6.
Therefore, I updated it in the [README.md](https://github.com/JamBalaya56562/attest-build-provenance/blob/bd77c077858b8d561b7a36cbe48ef4cc642ca39d/README.md?plain=1#L275).