### PR TITLE
Pin actions/attest reference by commit SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
   steps:
     - uses: actions/attest-build-provenance/predicate@1176ef556905f349f669722abf30bce1a6e16e01 # predicate@1.1.5
       id: generate-build-provenance-predicate
-    - uses: actions/attest@v2.2.1
+    - uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
While we await the official roll-out of [immutable actions](https://github.com/github/roadmap/issues/592) we'll continue to reference `actions/attest` by commit SHA (instead of immutable tag) in the `action.yml`.

https://github.com/actions/attest/commit/a63cfcc7d1aab266ee064c58250cfc2c7d07bc31