### PR TITLE
offboard from eslint in superlinter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Lint Codebase
         id: super-linter
-        uses: super-linter/super-linter/slim@v7.2.1
+        uses: super-linter/super-linter/slim@v7.3.0
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: dist/**/*
@@ -46,6 +46,10 @@ jobs:
           TYPESCRIPT_DEFAULT_STYLE: prettier
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JAVASCRIPT_STANDARD: false
+          VALIDATE_TYPESCRIPT_ES: false
           VALIDATE_TYPESCRIPT_STANDARD: false
           VALIDATE_JSCPD: false
           VALIDATE_YAML_PRETTIER: false
+
+      - name: Run eslint
+        run: npm run lint:eslint


### PR DESCRIPTION
Stop running eslint as part of the super-linter action. We've been pinned to an old version of super-linter cause the newer versions are not compatible with our updated eslint config. Until super-linter has support for eslint v9 we should leave this disabled.

Adds an explicit call to eslint to make-up for disabling it in super-linter.