### PR TITLE
Bump actions/attest from 2.3.0 to 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Attestations are saved in the JSON-serialized [Sigstore bundle][6] format.
 If multiple subjects are being attested at the same time, a single attestation
 will be created with references to each of the supplied subjects.
 
+The absolute path to the generated attestation is appended to the file
+`${RUNNER_TEMP}/created_attestation_paths.txt`. This file will accumulate the
+paths to all attestations created over the course of a single workflow.
+
 ## Attestation Limits
 
 ### Subject Limits

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
   steps:
     - uses: actions/attest-build-provenance/predicate@1176ef556905f349f669722abf30bce1a6e16e01 # predicate@1.1.5
       id: generate-build-provenance-predicate
-    - uses: actions/attest@afd638254319277bb3d7f0a234478733e2e46a73 # v2.3.0
+    - uses: actions/attest@ce27ba3b4a9a139d9a20a4a07d69fabb52f1e5bc # v2.4.0
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Updates the reference to the `actions/attest` action from v2.3.0 to v2.4.0.

https://github.com/actions/attest/releases/tag/v2.4.0