### PR TITLE
Adjust node max-http-header-size setting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,8 @@ runs:
       id: generate-build-provenance-predicate
     - uses: actions/attest@ce27ba3b4a9a139d9a20a4a07d69fabb52f1e5bc # v2.4.0
       id: attest
+      env:
+        NODE_OPTIONS: "--max-http-header-size=32768"
       with:
         subject-path: ${{ inputs.subject-path }}
         subject-digest: ${{ inputs.subject-digest }}


### PR DESCRIPTION
Closes: https://github.com/actions/attest-build-provenance/issues/606

When using the `push-to-registry` option some users have encountered header overflow issues when interacting with certain OCI registries.

By default, node [limits](https://nodejs.org/api/cli.html#--max-http-header-sizesize) the total size of headers received in a single response to 16KB. We have seen certain interactions with the Google Artifact Registry API return headers totaling 21KB.

This change updates the maximum allowed header size to 32KB in order to give us some more breathing room when interacting with these registries.