### PR TITLE
Bump actions/attest from v2.4.0 to v3.0.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
   steps:
     - uses: actions/attest-build-provenance/predicate@1176ef556905f349f669722abf30bce1a6e16e01 # predicate@1.1.5
       id: generate-build-provenance-predicate
-    - uses: actions/attest@ce27ba3b4a9a139d9a20a4a07d69fabb52f1e5bc # v2.4.0
+    - uses: actions/attest@daf44fb950173508f38bd2406030372c1d1162b1 # v3.0.0
       id: attest
       env:
         NODE_OPTIONS: "--max-http-header-size=32768"


### PR DESCRIPTION
Bump `actions/attest` to v3.0.0

https://github.com/actions/attest/releases/tag/v3.0.0