### PR TITLE
Bump attest-build-provenance/predicate to v2.0.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/attest-build-provenance/predicate@1176ef556905f349f669722abf30bce1a6e16e01 # predicate@1.1.5
+    - uses: actions/attest-build-provenance/predicate@864457a58d4733d7f1574bd8821fa24e02cf7538 # predicate@2.0.0
       id: generate-build-provenance-predicate
     - uses: actions/attest@daf44fb950173508f38bd2406030372c1d1162b1 # v3.0.0
       id: attest


### PR DESCRIPTION
Reference v2.0.0 of `actions/attest-build-provenance/predicate` -- includes support for the node24 runtime.