### PR TITLE
remove badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # `actions/attest-build-provenance`
 
-[![Public-Good Sigstore Prober](https://github.com/actions/attest-build-provenance/actions/workflows/prober-public-good.yml/badge.svg)](https://github.com/actions/attest-build-provenance/actions/workflows/prober-public-good.yml)
-[![GitHub Sigstore Prober](https://github.com/actions/attest-build-provenance/actions/workflows/prober-github.yml/badge.svg)](https://github.com/actions/attest-build-provenance/actions/workflows/prober-github.yml)
-
 Generate signed build provenance attestations for workflow artifacts. Internally
 powered by the [@actions/attest][1] package.
 


### PR DESCRIPTION
This pull request makes a small change to the `README.md` file by removing the workflow status badges for "Public-Good Sigstore Prober" and "GitHub Sigstore Prober".