### PR TITLE
Update actions/attest to v4.1.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ runs:
       id: attest
       env:
         NODE_OPTIONS: "--max-http-header-size=32768"
-      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+      uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
       with:
         subject-path: ${{ inputs.subject-path }}
         subject-name: ${{ inputs.subject-name }}


### PR DESCRIPTION
Bumps the pinned `actions/attest` reference from v4.1.0 to [v4.1.1](https://github.com/actions/attest/releases/tag/v4.1.1).

- `59d89421af93a897026c735860bf21b6eb4f7b26` (v4.1.0) → `a1948c3f048ba23858d222213b7c278aabede763` (v4.1.1)